### PR TITLE
[Base] Edit BaseViewModel for pagination

### DIFF
--- a/WebToonProject/Base/BaseViewModel.swift
+++ b/WebToonProject/Base/BaseViewModel.swift
@@ -6,11 +6,31 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
-protocol BaseViewModel {
+class BaseViewModel<T, I, O> {
+    typealias Input = I
+    typealias Output = O
     
-    associatedtype Input
-    associatedtype Output
+    // default value for pagination
+    var currentPage = 1
+    var hasNextPage = true
+    var resultToShow: [T] = []
     
-    func transform(_ input: Input) -> Output
+    let isLoading = BehaviorRelay<Bool>(value: false)
+    let resultList = PublishRelay<[T]>()
+    let errorMessage = PublishRelay<CustomError>()
+
+    let disposeBag = DisposeBag()
+
+    func transform(_ input: Input) -> Output {
+        fatalError("Subclasses must override transform(input:)")
+    }
+    
+    func resetPagination() {
+        currentPage = 1
+        hasNextPage = true
+        resultToShow = []
+    }
 }

--- a/WebToonProject/DailyWebtoon/DailyWebtoonView.swift
+++ b/WebToonProject/DailyWebtoon/DailyWebtoonView.swift
@@ -50,7 +50,7 @@ final class DailyWebtoonView: BaseView {
     private func createLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewFlowLayout()
         let screenWidth = UIScreen.main.bounds.width
-        let verticalInset: CGFloat = 8
+        let verticalInset: CGFloat = 12
         let horizontalInset: CGFloat = 12
         let horizontalSpacing: CGFloat = horizontalInset*2
         let itemSpacing: CGFloat = layout.minimumInteritemSpacing * 2

--- a/WebToonProject/Recommend/RecommendViewModel.swift
+++ b/WebToonProject/Recommend/RecommendViewModel.swift
@@ -10,13 +10,12 @@ import RxSwift
 import RxCocoa
 import Kingfisher
 
-final class RecommendViewModel: BaseViewModel {
+final class RecommendViewModel: BaseViewModel<Webtoon,
+                                RecommendViewModel.Input,
+                                RecommendViewModel.Output> {
     
-    private let resultList = PublishRelay<[Webtoon]>()
-    private let errorMessage = PublishRelay<CustomError>()
     private let bannerImages = PublishRelay<[UIImage]>()
 
-    private let disposeBag = DisposeBag()
     
     struct Input {
         let viewDidLoadTrigger: PublishRelay<Void>
@@ -29,7 +28,7 @@ final class RecommendViewModel: BaseViewModel {
         let errorMessage: PublishRelay<CustomError>
     }
     
-    func transform(_ input: Input) -> Output {
+    override func transform(_ input: Input) -> Output {
         input.viewDidLoadTrigger
             .bind(with: self) { owner, _ in
                 let shimmer = Webtoon.shimmer


### PR DESCRIPTION
### Feature  
- `BaseViewModel` 프로토콜 -> `BaseViewModel<T, Input, Output>` 추상 클래스로 변경했습니다.
  - 각 ViewModel에서 Pagination 을 위해 중복되던 상태값 (`currentPage`, `isLoading`, `resultToShow` 등) 공통화했습니다.
  - `transform(_:)` 메서드는 override 하도록 강제합니다.

- Changed `BaseViewModel<T, Input, Output>` protocol to abstract class  
  - Unified shared states for pagination like `currentPage`, `isLoading`, `resultToShow` in BaseViewModel class
  - Enforced subclassing `transform(_:)` method  

- プロトコルに定義されていた BaseViewModel を`BaseViewModel<T, Input, Output>` 抽象クラスに変換しました。
  - Pagination のため各 ViewModel で重複していた状態値（`currentPage`, `isLoading`, `resultToShow`など）を共通化しました。  
  - `transform(_:)` メソッドの override を必須に定義するようにします。