### PR TITLE
[Fix] Adjust CollectionView Height

### DIFF
--- a/WebToonProject/Feature/Recommend/RecommendView.swift
+++ b/WebToonProject/Feature/Recommend/RecommendView.swift
@@ -38,13 +38,6 @@ final class RecommendView: BaseView {
         
         return layout
     }
-        
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        collectionView.layoutIfNeeded()
-        let contentHeight = collectionView.collectionViewLayout.collectionViewContentSize.height
-        collectionViewHeightConstraint?.update(offset: contentHeight)
-    }
 
     // MARK: - Hierarchy
     override func configureHierarchy() {
@@ -108,5 +101,11 @@ final class RecommendView: BaseView {
         collectionView.register(UINib(nibName: BasicCollectionViewCell.identifier, bundle: nil),
                                               forCellWithReuseIdentifier: BasicCollectionViewCell.identifier)
         collectionView.isScrollEnabled = false
+    }
+    
+    func updateCollectionViewHeight() {
+        collectionView.layoutIfNeeded()
+        let contentHeight = collectionView.collectionViewLayout.collectionViewContentSize.height
+        collectionViewHeightConstraint?.update(offset: contentHeight)
     }
 }

--- a/WebToonProject/Feature/Recommend/RecommendViewController.swift
+++ b/WebToonProject/Feature/Recommend/RecommendViewController.swift
@@ -48,6 +48,12 @@ final class RecommendViewController: BaseViewController {
                 }
                 .disposed(by: disposeBag)
         
+        output.resultList
+            .drive(with: self) { owner, _ in
+                owner.recommendView.updateCollectionViewHeight()
+            }
+            .disposed(by: disposeBag)
+
         output.bannerImages
             .drive(onNext: { [weak self] images in
                 self?.recommendView.bannerView.setImages(images)

--- a/WebToonProject/Feature/Recommend/RecommendViewModel.swift
+++ b/WebToonProject/Feature/Recommend/RecommendViewModel.swift
@@ -31,7 +31,7 @@ final class RecommendViewModel: BaseViewModel<Webtoon,
         input.viewDidLoadTrigger
             .bind(with: self) { owner, _ in
                 let shimmer = Webtoon.shimmer
-                owner.resultList.accept(Array(repeating: shimmer, count: 6))
+                owner.resultList.accept(Array(repeating: shimmer, count: 12))
                 owner.callRequestToNetworkManager()
             }
             .disposed(by: disposeBag)


### PR DESCRIPTION
### 🐛 문제
- 화면 진입 직후 보여줄 셀(Shimmer)만 높이에 반영되기 때문에  
  실제 데이터가 추가로 들어와도 `collectionView` 높이가 다시 계산되지 않음.

### 🛠 해결
- View에 `updateCollectionViewHeight()` 함수를 제작하여 외부에서 수동 호출 가능하게 함
- `collectionView.collectionViewLayout.collectionViewContentSize.height` 사용
- ViewModel → 실제 데이터 emit 이후, ViewController에서 명시적으로 높이 업데이트 실행

![Simulator Screen Recording - iPhone 15 - 2025-03-24 at 15 17 44](https://github.com/user-attachments/assets/2bee9711-5d83-4170-8fc0-e0e4f5da1b7f)

```swift
func updateCollectionViewHeight() {
    collectionView.layoutIfNeeded()
    let contentHeight = collectionView.collectionViewLayout.collectionViewContentSize.height
    collectionViewHeightConstraint?.update(offset: contentHeight)
}