### PR TITLE
[Fix] Hide unnecessary imageViews from TableView Cell for LikeView

### DIFF
--- a/WebToonProject/Feature/LikeList/LikeListView.swift
+++ b/WebToonProject/Feature/LikeList/LikeListView.swift
@@ -44,11 +44,9 @@ final class LikeListView: BaseView {
         super.configureView()
         
         countLabel.font = .pretendardBold(ofSize: 14)
-        countLabel.text = Resources.Keys.howMany.localized
         countLabel.textColor = .black
         
         sortButton.titleLabel?.font = .pretendardRegular(ofSize: 14)
-        sortButton.setTitle(Resources.Keys.sortByReg.localized, for: .normal)
         
         tableView.rowHeight = 140
         tableView.register(

--- a/WebToonProject/Feature/LikeList/LikeListViewController.swift
+++ b/WebToonProject/Feature/LikeList/LikeListViewController.swift
@@ -55,6 +55,7 @@ final class LikeListViewController: BaseViewController {
                 cellIdentifier: BasicTableViewCell.identifier,
                 cellType: BasicTableViewCell.self)) { index, item, cell in
                     cell.configureData(item)
+                    cell.hideRatingInfo()
                 }
             .disposed(by: disposeBag)
 

--- a/WebToonProject/Feature/LikeList/LikeListViewModel.swift
+++ b/WebToonProject/Feature/LikeList/LikeListViewModel.swift
@@ -10,7 +10,9 @@ import RxSwift
 import RxCocoa
 import RealmSwift
 
-final class LikeListViewModel: BaseViewModel<LikedWebtoon, LikeListViewModel.Input, LikeListViewModel.Output> {
+final class LikeListViewModel: BaseViewModel<LikedWebtoon,
+                               LikeListViewModel.Input,
+                               LikeListViewModel.Output> {
 
     enum SortType {
         case title, regDate
@@ -32,7 +34,7 @@ final class LikeListViewModel: BaseViewModel<LikedWebtoon, LikeListViewModel.Inp
     private var currentSort: SortType = .regDate
 
     private let resultRelay = BehaviorRelay<[Webtoon]>(value: [])
-    private let sortTitleRelay = BehaviorRelay<String>(value: "등록순")
+    private let sortTitleRelay = BehaviorRelay<String>(value: "")
 
     private var currentSortTitle: String {
         currentSort == .title ? Resources.Keys.sortByTitle.localized : Resources.Keys.sortByReg.localized
@@ -43,6 +45,7 @@ final class LikeListViewModel: BaseViewModel<LikedWebtoon, LikeListViewModel.Inp
 
         input.viewWillAppear
             .bind(with: self) { owner, _ in
+                owner.sortTitleRelay.accept(owner.currentSortTitle)
                 owner.fetchSorted()
             }
             .disposed(by: disposeBag)

--- a/WebToonProject/Shared/Component/BasicTableViewCell.swift
+++ b/WebToonProject/Shared/Component/BasicTableViewCell.swift
@@ -103,4 +103,10 @@ class BasicTableViewCell: UITableViewCell {
         shimmerViews.forEach { $0.stopShimmering() }
         shimmerViews.removeAll()
     }
+    
+    func hideRatingInfo() {
+        infoImageView.isHidden = true
+        ratingLabel.isHidden = true
+        starImageViews.forEach { $0.isHidden = true }
+    }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0665499d-3231-4e92-b7bf-82c7fc5e687c)
 
 ### Note

- 좋아요 뷰에서는 Realm 에 로컬 저장된 웹툰 정보를 가지고 오기 때문에 info 정보를 실시간으로 보여주기 어렵다고 판단하여, 불필요한 ImageView 들은 hidden 처리 하였습니다.
- Since the Like view uses locally stored webtoon data from Realm, it is difficult to update the info in real time. Therefore, unnecessary `ImageView`s are hidden.
- いいね画面では Realm にローカル保存されたマンガ情報を使用しているため、リアルタイムで情報を更新するのが難しいと判断し、不要な `ImageView` は非表示にしました。