### PR TITLE
[Feat] [General] Add Alert for errors

### DIFF
--- a/WebToonProject/App/AlertResources.swift
+++ b/WebToonProject/App/AlertResources.swift
@@ -1,0 +1,41 @@
+//
+//  AlertResources.swift
+//  WebToonProject
+//
+//  Created by Kyuhee hong on 3/24/25.
+//
+
+import Foundation
+
+protocol AlertConvertible {
+    var title: String { get }
+    var message: String { get }
+}
+
+enum AlertType: String {
+    case screenShot
+}
+
+enum CustomError: String, Error {
+    case askAdmin
+    case serverIssue
+    case noInternet
+}
+
+extension AlertType: AlertConvertible {
+    var title: String {
+        NSLocalizedString("\(rawValue)Title", comment: "")
+    }
+    var message: String {
+        NSLocalizedString("\(rawValue)Message", comment: "")
+    }
+}
+
+extension CustomError: AlertConvertible {
+    var title: String {
+        NSLocalizedString("\(rawValue)Title", comment: "")
+    }
+    var message: String {
+        NSLocalizedString("\(rawValue)Message", comment: "")
+    }
+}

--- a/WebToonProject/App/Localizable.xcstrings
+++ b/WebToonProject/App/Localizable.xcstrings
@@ -1,6 +1,75 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "askAdminMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理者にお問い合わせください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "관리자에게 문의해주세요."
+          }
+        }
+      }
+    },
+    "askAdminTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please contact to Administrator"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問題が発生しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "문제가 발생했습니다."
+          }
+        }
+      }
+    },
+    "confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "confirm"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인"
+          }
+        }
+      }
+    },
     "daily" : {
       "comment" : "for navigation title",
       "extractionState" : "manual",
@@ -169,7 +238,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Please check your connect condition"
+            "value" : "You’re offline. Check your connection."
           }
         },
         "ja" : {
@@ -192,13 +261,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No Internet"
+            "value" : "No Internet Connection"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "エラーが発生しました。"
+            "value" : "接続できません。"
           }
         },
         "ko" : {
@@ -307,19 +376,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Caution"
+            "value" : "Screenshot detected"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ご注意"
+            "value" : "スクリーンショット検知"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "주의해주세요"
+            "value" : "스크린샷이 감지되었습니다."
           }
         }
       }
@@ -435,6 +504,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "최근 업데이트"
+          }
+        }
+      }
+    },
+    "serverIssueMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server is unstable. Please Try later."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバー側に問題が発生しております。しばらくお待ちの上再度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
+    "serverIssueTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "에러 발생"
           }
         }
       }

--- a/WebToonProject/App/Resources.swift
+++ b/WebToonProject/App/Resources.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 enum Resources {
-
+    
     enum SystemImage: String {
         case back = "arrow.left"
         case search = "magnifyingglass"
@@ -47,6 +47,7 @@ enum Resources {
         case search
         case like
         case daily
+        case confirm
         
         //button title
         case dailyWebtoon
@@ -101,19 +102,6 @@ enum Resources {
                 7: .sat
             ]
             return weekdayMap[weekdayIndex]
-        }
-    }
-    
-    enum AlertType: String {
-        case screenShot
-        case noInternet
-        
-        var title: String {
-            NSLocalizedString("\(rawValue)Title", comment: "")
-        }
-
-        var message: String {
-            NSLocalizedString("\(rawValue)Message", comment: "")
         }
     }
 }

--- a/WebToonProject/Base/BaseViewController.swift
+++ b/WebToonProject/Base/BaseViewController.swift
@@ -21,7 +21,7 @@ class BaseViewController: UIViewController {
     
     func showAlert(title: String, message: String) {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "확인", style: .default)
+        let confirmAction = UIAlertAction(title: Resources.Keys.confirm.localized, style: .default)
         alertController.addAction(confirmAction)
         present(alertController, animated: true)
     }

--- a/WebToonProject/Feature/DailyWebtoon/DailyWebtoonViewController.swift
+++ b/WebToonProject/Feature/DailyWebtoon/DailyWebtoonViewController.swift
@@ -71,6 +71,13 @@ final class DailyWebtoonViewController: BaseViewController {
                 }
                 .disposed(by: disposeBag)
         
+        output.errorMessage
+            .bind(with: self) { owner, customError in
+                owner.showAlert(title: customError.title,
+                                message: customError.message)
+            }
+            .disposed(by: disposeBag)
+        
         dailyWebtoonView.collectionView.rx.modelSelected(Webtoon.self)
             .bind(with: self) { owner, item in
                 let nextVC = ImageViewerViewController()

--- a/WebToonProject/Feature/ImageViewer/ImageViewerViewController.swift
+++ b/WebToonProject/Feature/ImageViewer/ImageViewerViewController.swift
@@ -86,6 +86,13 @@ final class ImageViewerViewController: BaseViewController {
                 }
                 .disposed(by: disposeBag)
         
+        output.errorMessage
+            .bind(with: self) { owner, customError in
+                    owner.showAlert(title: customError.title,
+                                    message: customError.message)
+            }
+            .disposed(by: disposeBag)
+        
         imageViewerView.backButton.rx.tap
             .bind(with: self) { owner, _ in
                 owner.navigationController?.popViewController(animated: true)
@@ -189,8 +196,8 @@ extension ImageViewerViewController {
     }
     
     @objc private func handleScreenshot() {
-        self.showAlert(title: Resources.AlertType.screenShot.title,
-                       message: Resources.AlertType.screenShot.message)
+        self.showAlert(title: AlertType.screenShot.title,
+                       message: AlertType.screenShot.message)
     }
 
 }

--- a/WebToonProject/Feature/Recommend/RecommendViewController.swift
+++ b/WebToonProject/Feature/Recommend/RecommendViewController.swift
@@ -28,6 +28,11 @@ final class RecommendViewController: BaseViewController {
         viewDidLoadTrigger.accept(())
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewDidLoadTrigger.accept(())
+    }
+    
     private func bind() {
         let input = RecommendViewModel.Input(
             viewDidLoadTrigger: viewDidLoadTrigger,
@@ -59,6 +64,13 @@ final class RecommendViewController: BaseViewController {
             .drive(onNext: { [weak self] images in
                 self?.recommendView.bannerView.setImages(images)
             })
+            .disposed(by: disposeBag)
+        
+        output.errorMessage
+            .bind(with: self) { owner, customError in
+                owner.showAlert(title: customError.title,
+                                message: customError.message)
+            }
             .disposed(by: disposeBag)
         
         recommendView.dailyButton.rx.tap

--- a/WebToonProject/Feature/Search/SearchViewController.swift
+++ b/WebToonProject/Feature/Search/SearchViewController.swift
@@ -112,6 +112,13 @@ final class SearchViewController: BaseViewController {
             }
             .disposed(by: disposeBag)
         
+        output.errorMessage
+            .bind(with: self) { owner, customError in
+                owner.showAlert(title: customError.title,
+                                message: customError.message)
+            }
+            .disposed(by: disposeBag)
+        
         searchView.tableView.rx.modelSelected(Webtoon.self)
             .bind(with: self) { owner, item in
                 let nextVC = ImageViewerViewController()


### PR DESCRIPTION
## 🔔 Alert 메시지 다국어 적용 및 처리 방식 개선

### Preview
![Simulator Screen Recording - iPhone 15 - 2025-03-24 at 20 43 51](https://github.com/user-attachments/assets/400f4a3b-7de4-47ab-ab73-c6ebd4245df3)

### Feature
- Alert 메시지를 `enum`으로 정의하여 `title`과 `message`를 함께 관리할 수 있도록 개선했습니다.
  - Improved alert message structure using `enum`, combining `title` and `message` definitions.
  - `enum`を使ってアラートのタイトルとメッセージを一括で管理できるように改善しました。

- 각 메시지에 대해 NSLocalizedString을 적용하여 다국어를 지원하도록 했습니다.
  - Applied `NSLocalizedString` to support localization for multiple languages.
  - 各メッセージに対して `NSLocalizedString` を適用し、多言語対応を行いました。

- 네트워크 오류 등의 상황에서 Alert를 통해 사용자에게 안내 메시지를 제공하도록 했습니다.
  - Error messages such as network failures are now shown clearly to users through alert pop-ups.
  - ネットワークエラーなどの発生時に、ユーザーにわかりやすいメッセージをアラートで表示するようにしました。